### PR TITLE
Implement Linux Transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,33 @@ Dependency: `"Tmds.Kestrel.Linux": "0.1.0-*"`
 
 # Design
 
-...
+## General
+
+Since this library doesn't aim to be xplat or provide a generic networking API, we can include only what is necessary and
+optimize for the specific use-case.
+
+**For example**: the libuv and corfx async socket APIs have a receive and send function. Since these functinos are async, their
+arguments (e.g. `uv_buf_t`, `SocketAsyncEventArgs`) must be allocated on the heap. To reduce pressure on the GC, these types
+can be pooled. In this library, the async operations on the limited to waiting for a socket to be come readable/writable. These operations
+don't have arguments so they don't require allocation and pooling.
+
+## Threading
+
+### Kestrel libuv
+
+The kestrel libuv implementation has a one listener thread that accepts incoming connection and then passes these off to
+other threads for processing. Connections are distributed round-robin between the threads.
+
+See [ListenerPrimary.cs](https://github.com/aspnet/KestrelHttpServer/blob/7d3bcd2bf868dbd65741da1569ce974993a8e720/src/Microsoft.AspNetCore.Server.Kestrel/Internal/Http/ListenerPrimary.cs#L97-L121)
+
+### .NET Core Framework
+
+`System.Net.Sockets.Socket` has one thread that monitors asynchronous socket events.
+
+See [SocketAsyncEngine.Unix.cs](https://github.com/dotnet/corefx/blob/4611d411d892bd4c4fa9e4dfc2e4cdbb89fea799/src/System.Net.Sockets/src/System/Net/Sockets/SocketAsyncEngine.Unix.cs#L58).
+
+### Tmds.Kestrel.Linux
+
+The implementation starts a number of threads which each accept connections. This is based on [`SO_REUSEPORT`](https://lwn.net/Articles/542629/)
+socket option. This option allow multiple sockets to concurrently bind and listen to the same port. The kernel performs
+load-balancing between the listen sockets.

--- a/src/Tmds.Kestrel.Linux/Kestrel.cs
+++ b/src/Tmds.Kestrel.Linux/Kestrel.cs
@@ -1,0 +1,25 @@
+using System.IO.Pipelines;
+using System.Net;
+
+namespace Kestrel
+{
+    // interfaces per https://github.com/aspnet/KestrelHttpServer/issues/828
+
+    public interface IConnectionHandler
+    {
+        IConnectionContext OnConnection(IConnectionInformation connectionInfo, PipeOptions inputOptions, PipeOptions outputOptions);
+    }
+
+    public interface IConnectionContext
+    {
+        string ConnectionId { get; }
+        IPipeWriter Input { get; }
+        IPipeReader Output { get; }
+    }
+
+    public interface IConnectionInformation
+    {
+        IPEndPoint RemoteEndPoint { get; }
+        IPEndPoint LocalEndPoint { get; }
+    }
+}

--- a/src/Tmds.Kestrel.Linux/Transport.cs
+++ b/src/Tmds.Kestrel.Linux/Transport.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Kestrel;
+
+namespace Tmds.Kestrel.Linux
+{
+    public class Transport
+    {
+        private static readonly TransportThread[] EmptyThreads = Array.Empty<TransportThread>();
+        private IPEndPoint[] _listenEndPoints;
+        private IConnectionHandler _connectionHandler;
+        private int _threadCount;
+        private TransportThread[] _threads;
+        private TransportOptions _transportOptions;
+
+        public Transport(IPEndPoint[] listenEndPoints, IConnectionHandler connectionHandler, TransportOptions transportOptions)
+        {
+            if (listenEndPoints == null)
+            {
+                throw new ArgumentNullException(nameof(listenEndPoints));
+            }
+            if (connectionHandler == null)
+            {
+                throw new ArgumentNullException(nameof(connectionHandler));
+            }
+            if (transportOptions == null)
+            {
+                throw new ArgumentException(nameof(transportOptions));
+            }
+            if (listenEndPoints.Length < 1)
+            {
+                throw new ArgumentException(nameof(listenEndPoints));
+            }
+            foreach (var listenEndPoint in listenEndPoints)
+            {
+                if (listenEndPoint == null)
+                {
+                    throw new ArgumentException(nameof(listenEndPoints));
+                }
+            }
+
+            _listenEndPoints = listenEndPoints;
+            _connectionHandler = connectionHandler;
+            _transportOptions = transportOptions;
+            _threadCount = _transportOptions.ThreadCount;
+        }
+
+        public Task BindAsync()
+        {
+            var threads = new TransportThread[_threadCount];
+            for (int i = 0; i < _threadCount; i++)
+            {
+                var thread = new TransportThread(_connectionHandler, _transportOptions);
+                threads[i] = thread;
+            }
+            var original = Interlocked.CompareExchange(ref _threads, threads, null);
+            ThrowIfInvalidState(state: original, starting: true);
+
+            for (int i = 0; i < threads.Length; i++)
+            {
+                threads[i].Start();
+                foreach (var listenEndPoint in _listenEndPoints)
+                {
+                    threads[i].AcceptOn(listenEndPoint);
+                }
+            }
+            return Task.CompletedTask;
+        }
+
+        public Task UnbindAsync()
+        {
+            var threads = Volatile.Read(ref _threads);
+            ThrowIfInvalidState(state: threads, starting: false);
+            var tasks = new Task[threads.Length];
+            for (int i = 0; i < threads.Length; i++)
+            {
+                tasks[i] = threads[i].CloseAcceptAsync();
+            }
+            return Task.WhenAll(tasks);
+        }
+
+        public Task StopAsync()
+        {
+            var threads = Volatile.Read(ref _threads);
+            ThrowIfInvalidState(state: threads, starting: false);
+            var tasks = new Task[threads.Length];
+            for (int i = 0; i < threads.Length; i++)
+            {
+                tasks[i] = threads[i].StopAsync();
+            }
+            return Task.WhenAll(tasks);
+        }
+
+        public void Dispose()
+        {
+            var threads = Interlocked.Exchange(ref _threads, EmptyThreads);
+            if (threads.Length == 0)
+            {
+                return;
+            }
+            var tasks = new Task[threads.Length];
+            for (int i = 0; i < threads.Length; i++)
+            {
+                tasks[i] = threads[i].StopAsync();
+            }
+            try
+            {
+                Task.WaitAll(tasks);
+            }
+            finally
+            {}
+        }
+
+        private void ThrowIfInvalidState(TransportThread[] state, bool starting)
+        {
+            if (state == EmptyThreads)
+            {
+                throw new ObjectDisposedException(nameof(Transport));
+            }
+            else if (state == null && !starting)
+            {
+                throw new InvalidOperationException("Not started");
+            }
+            else if (state != null && starting)
+            {
+                throw new InvalidOperationException("Already starting");
+            }
+        }
+    }
+}

--- a/src/Tmds.Kestrel.Linux/TransportOptions.cs
+++ b/src/Tmds.Kestrel.Linux/TransportOptions.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Tmds.Kestrel.Linux
+{
+    public class TransportOptions
+    {
+        public int ThreadCount { get; set; } = ProcessorThreadCount;
+
+        private static int ProcessorThreadCount
+        {
+            get
+            {
+                // Kestrel implementation
+
+                // Actual core count would be a better number
+                // rather than logical cores which includes hyper-threaded cores.
+                // Divide by 2 for hyper-threading, and good defaults (still need threads to do webserving).
+                var threadCount = Environment.ProcessorCount >> 1;
+
+                if (threadCount < 1)
+                {
+                    // Ensure shifted value is at least one
+                    return 1;
+                }
+
+                if (threadCount > 16)
+                {
+                    // Receive Side Scaling RSS Processor count currently maxes out at 16
+                    // would be better to check the NIC's current hardware queues; but xplat...
+                    return 16;
+                }
+
+                return threadCount;
+            }
+        }
+    }
+}

--- a/src/Tmds.Kestrel.Linux/TransportOptions.cs
+++ b/src/Tmds.Kestrel.Linux/TransportOptions.cs
@@ -10,27 +10,8 @@ namespace Tmds.Kestrel.Linux
         {
             get
             {
-                // Kestrel implementation
-
-                // Actual core count would be a better number
-                // rather than logical cores which includes hyper-threaded cores.
-                // Divide by 2 for hyper-threading, and good defaults (still need threads to do webserving).
-                var threadCount = Environment.ProcessorCount >> 1;
-
-                if (threadCount < 1)
-                {
-                    // Ensure shifted value is at least one
-                    return 1;
-                }
-
-                if (threadCount > 16)
-                {
-                    // Receive Side Scaling RSS Processor count currently maxes out at 16
-                    // would be better to check the NIC's current hardware queues; but xplat...
-                    return 16;
-                }
-
-                return threadCount;
+                // cfr Netty
+                return Environment.ProcessorCount << 1;
             }
         }
     }

--- a/src/Tmds.Kestrel.Linux/TransportThread.TSocket.cs
+++ b/src/Tmds.Kestrel.Linux/TransportThread.TSocket.cs
@@ -39,6 +39,8 @@ namespace Tmds.Kestrel.Linux
             public int         Key;
             public Socket      Socket;
             public IPipeReader PipeReader;
+            public IPEndPoint  PeerAddress;
+            public IPEndPoint  LocalAddress;
 
             private Action _writableCompletion;
             bool IWritableAwaiter.IsCompleted
@@ -135,25 +137,9 @@ namespace Tmds.Kestrel.Linux
             public ReadableAwaitable ReadableAwaitable => new ReadableAwaitable(this);
             public WritableAwaitable WritableAwaitable => new WritableAwaitable(this);
 
-            IPEndPoint IConnectionInformation.RemoteEndPoint
-            {
-                get
-                {
-                    IPEndPoint rv;
-                    Socket.TryGetPeerIPAddress(out rv);
-                    return rv;
-                }
-            }
+            IPEndPoint IConnectionInformation.RemoteEndPoint => PeerAddress;
 
-            IPEndPoint IConnectionInformation.LocalEndPoint
-            {
-                get
-                {
-                    IPEndPoint rv;
-                    Socket.TryGetLocalIPAddress(out rv);
-                    return rv;
-                }
-            }
+            IPEndPoint IConnectionInformation.LocalEndPoint => LocalAddress;
         }
 
         interface IReadableAwaiter

--- a/src/Tmds.Kestrel.Linux/TransportThread.TSocket.cs
+++ b/src/Tmds.Kestrel.Linux/TransportThread.TSocket.cs
@@ -1,0 +1,217 @@
+using System;
+using System.IO.Pipelines;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Kestrel;
+
+namespace Tmds.Kestrel.Linux
+{
+    partial class TransportThread
+    {
+        [Flags]
+        enum SocketFlags
+        {
+            AwaitReadable   = EPollEvents.Readable, // 0x01, EPOLLIN
+            AwaitWritable   = EPollEvents.Writable, // 0x04, EPOLLOUT
+
+            EPollEventMask  = AwaitReadable | AwaitWritable,
+
+            EPollRegistered = 0x08,
+
+            ShutdownSend    = 0x10,
+            ShutdownReceive = 0x20,
+
+            TypeAccept      = 0x00,
+            TypeClient      = 0x40,
+            TypePipe        = 0x80,
+
+            TypeMask        = 0xC0,
+
+            Stopping         = 0x100
+        }
+
+        class TSocket : IReadableAwaiter, IWritableAwaiter, IConnectionInformation
+        {
+            private static readonly Action _completedSentinel = delegate { };
+
+            public SocketFlags Flags;
+            public int         Key;
+            public Socket      Socket;
+            public IPipeReader PipeReader;
+
+            private Action _writableCompletion;
+            bool IWritableAwaiter.IsCompleted
+            {
+                get
+                {
+                    return ReferenceEquals(_completedSentinel, Volatile.Read(ref _writableCompletion));
+                }
+            }
+            bool IWritableAwaiter.GetResult()
+            {
+                return (Flags & SocketFlags.Stopping) != 0;
+            }
+            void IWritableAwaiter.OnCompleted(Action continuation)
+            {
+                if (continuation != null)
+                {
+                    var oldValue = Interlocked.CompareExchange(ref _writableCompletion, continuation, null);
+
+                    if (ReferenceEquals(oldValue, _completedSentinel))
+                    {
+                        // already complete; calback sync
+                        continuation.Invoke();
+                    }
+                }
+            }
+            public void CompleteWritable(bool stopping = false)
+            {
+                if (stopping)
+                {
+                    lock (this)
+                    {
+                        Flags |= SocketFlags.Stopping;
+                    }
+                }
+
+                Action continuation = Interlocked.Exchange(ref _writableCompletion, _completedSentinel);
+                if (continuation != null && !ReferenceEquals(continuation, _completedSentinel))
+                {
+                    continuation.Invoke();
+                }
+            }
+            public void ResetWritableAwaitable()
+            {
+                Volatile.Write(ref _writableCompletion, null);
+            }
+
+            private Action _readableCompletion;
+            bool IReadableAwaiter.IsCompleted
+            {
+                get
+                {
+                    return ReferenceEquals(_completedSentinel, Volatile.Read(ref _readableCompletion));
+                }
+            }
+            bool IReadableAwaiter.GetResult()
+            {
+                return (Flags & SocketFlags.Stopping) != 0;
+            }
+            void IReadableAwaiter.OnCompleted(Action continuation)
+            {
+                if (continuation != null)
+                {
+                    var oldValue = Interlocked.CompareExchange(ref _readableCompletion, continuation, null);
+
+                    if (ReferenceEquals(oldValue, _completedSentinel))
+                    {
+                        // already complete; calback sync
+                        continuation.Invoke();
+                    }
+                }
+            }
+            public void CompleteReadable(bool stopping = false)
+            {
+                if (stopping)
+                {
+                    lock (this)
+                    {
+                        Flags |= SocketFlags.Stopping;
+                    }
+                }
+
+                Action continuation = Interlocked.Exchange(ref _readableCompletion, _completedSentinel);
+                if (continuation != null && !ReferenceEquals(continuation, _completedSentinel))
+                {
+                    continuation.Invoke();
+                }
+            }
+            public void ResetReadableAwaitable()
+            {
+                Volatile.Write(ref _readableCompletion, null);
+            }
+
+            public ReadableAwaitable ReadableAwaitable => new ReadableAwaitable(this);
+            public WritableAwaitable WritableAwaitable => new WritableAwaitable(this);
+
+            IPEndPoint IConnectionInformation.RemoteEndPoint
+            {
+                get
+                {
+                    IPEndPoint rv;
+                    Socket.TryGetPeerIPAddress(out rv);
+                    return rv;
+                }
+            }
+
+            IPEndPoint IConnectionInformation.LocalEndPoint
+            {
+                get
+                {
+                    IPEndPoint rv;
+                    Socket.TryGetLocalIPAddress(out rv);
+                    return rv;
+                }
+            }
+        }
+
+        interface IReadableAwaiter
+        {
+            bool IsCompleted { get; }
+
+            bool GetResult();
+
+            void OnCompleted(Action continuation);
+        }
+
+        interface IWritableAwaiter
+        {
+            bool IsCompleted { get; }
+
+            bool GetResult();
+
+            void OnCompleted(Action continuation);
+        }
+
+        struct ReadableAwaitable: ICriticalNotifyCompletion
+        {
+            private readonly IReadableAwaiter _awaiter;
+
+            public ReadableAwaitable(TSocket awaiter)
+            {
+                _awaiter = awaiter;
+            }
+
+            public bool IsCompleted => _awaiter.IsCompleted;
+
+            public bool GetResult() => _awaiter.GetResult();
+
+            public ReadableAwaitable GetAwaiter() => this;
+
+            public void UnsafeOnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+
+            public void OnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+        }
+
+        struct WritableAwaitable: ICriticalNotifyCompletion
+        {
+            private readonly IWritableAwaiter _awaiter;
+
+            public WritableAwaitable(IWritableAwaiter awaiter)
+            {
+                _awaiter = awaiter;
+            }
+
+            public bool IsCompleted => _awaiter.IsCompleted;
+
+            public bool GetResult() => _awaiter.GetResult();
+
+            public WritableAwaitable GetAwaiter() => this;
+
+            public void UnsafeOnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+
+            public void OnCompleted(Action continuation) => _awaiter.OnCompleted(continuation);
+        }
+    }
+}

--- a/src/Tmds.Kestrel.Linux/TransportThread.cs
+++ b/src/Tmds.Kestrel.Linux/TransportThread.cs
@@ -1,0 +1,718 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Kestrel;
+using Tmds.Posix;
+
+namespace Tmds.Kestrel.Linux
+{
+    partial class TransportThread
+    {
+        private const int ListenBacklog = 128;
+        private const int EventBufferLength = 512;
+        private static PipeOptions DefaultPipeOptions = new PipeOptions();
+
+        enum State
+        {
+            Initial,
+            Started,
+            ClosingAccept,
+            AcceptClosed,
+            Stopping,
+            Stopped
+        }
+
+        private readonly IConnectionHandler _connectionHandler;
+
+        private State _state;
+        private readonly object _gate = new object();
+        private ConcurrentDictionary<int, TSocket> _sockets;
+        private List<TSocket> _acceptSockets;
+        private EPoll _epoll;
+        private PipeEndPair _pipeEnds;
+        private Thread _thread;
+        private TaskCompletionSource<object> _stateChangeCompletion;
+
+        public TransportThread(IConnectionHandler connectionHandler, TransportOptions options)
+        {
+            if (connectionHandler == null)
+            {
+                throw new ArgumentNullException(nameof(connectionHandler));
+            }
+            _connectionHandler = connectionHandler;
+        }
+
+        public void Start()
+        {
+            lock (_gate)
+            {
+                if (_state != State.Initial)
+                {
+                    ThrowInvalidState();
+                }
+                try
+                {
+                    _sockets = new ConcurrentDictionary<int, TSocket>();
+                    _acceptSockets = new List<TSocket>();
+
+                    _epoll = EPoll.Create();
+
+                    _pipeEnds = PipeEnd.CreatePair(blocking: false);
+                    var tsocket = new TSocket()
+                    {
+                        Flags = SocketFlags.TypePipe,
+                        Key = _pipeEnds.ReadEnd.DangerousGetHandle().ToInt32()
+                    };
+                    _sockets.TryAdd(tsocket.Key, tsocket);
+                    _epoll.Control(EPollOperation.Add, _pipeEnds.ReadEnd, EPollEvents.Readable, new EPollData { Int1 = tsocket.Key, Int2 = tsocket.Key });
+
+                    _state = State.Started;
+   
+                    _thread = new Thread(PollThread);
+                    _thread.Start();
+                }
+                catch
+                {
+                    _state = State.Stopped;
+                    _epoll?.Dispose();
+                    _pipeEnds.Dispose();
+                    throw;
+                }
+            }
+        }
+
+        public void AcceptOn(System.Net.IPEndPoint endPoint)
+        {
+            lock (_gate)
+            {
+                if (_state != State.Started)
+                {
+                    ThrowInvalidState();
+                }
+
+                Socket acceptSocket = null;
+                int key = 0;
+                int port = endPoint.Port;
+                try
+                {
+                    bool ipv4 = endPoint.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork;
+                    acceptSocket = Socket.Create(ipv4 ? AddressFamily.InterNetwork : AddressFamily.InterNetworkV6, SocketType.Stream, ProtocolType.Tcp, blocking: false);
+                    key = acceptSocket.DangerousGetHandle().ToInt32();
+                    if (!ipv4)
+                    {
+                        // Don't do mapped ipv4
+                        acceptSocket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.IPv6Only, 1);
+                    }
+                    // Linux: allow bind during linger time
+                    acceptSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, 1);
+                    // Linux: allow concurrent binds and let the kernel do load-balancing
+                    acceptSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReusePort, 1);
+
+                    acceptSocket.Bind(endPoint);
+                    if (port == 0)
+                    {
+                        // When testing we want the OS to select a free port
+                        port = acceptSocket.GetLocalIPAddress().Port;
+                    }
+
+                    acceptSocket.Listen(ListenBacklog);
+                }
+                catch
+                {
+                    acceptSocket?.Dispose();
+                    throw;
+                }
+
+                TSocket tsocket = null;
+                try
+                {
+                    tsocket = new TSocket()
+                    {
+                        Flags = SocketFlags.TypeAccept,
+                        Key = key,
+                        Socket = acceptSocket
+                    };
+                    _acceptSockets.Add(tsocket);
+                    _sockets.TryAdd(tsocket.Key, tsocket);
+
+                    _epoll.Control(EPollOperation.Add, acceptSocket, EPollEvents.Readable, new EPollData { Int1 = tsocket.Key, Int2 = tsocket.Key });
+                }
+                catch
+                {
+                    acceptSocket.Dispose();
+                    _acceptSockets.Remove(tsocket);
+                    _sockets.TryRemove(key, out tsocket);
+                    throw;
+                }
+                endPoint.Port = port;
+            }
+        }
+
+        public Task CloseAcceptAsync()
+        {
+            TaskCompletionSource<object> tcs;
+            lock (_gate)
+            {
+                if (_state == State.Initial)
+                {
+                    _state = State.Stopped;
+                    return Task.CompletedTask;
+                }
+                else if (_state == State.AcceptClosed || _state == State.Stopping || _state == State.Stopped)
+                {
+                    return Task.CompletedTask;
+                }
+                else if (_state == State.ClosingAccept)
+                {
+                    return _stateChangeCompletion.Task;
+                }
+                else if (_state != State.Started)
+                {
+                    // Cannot happen
+                    ThrowInvalidState();
+                }
+                tcs = _stateChangeCompletion = new TaskCompletionSource<object>();
+                _state = State.ClosingAccept;
+            }
+            _pipeEnds.WriteEnd.WriteByte(0);
+            return tcs.Task;
+        }
+
+        public async Task StopAsync()
+        {
+            lock (_gate)
+            {
+                if (_state == State.Initial)
+                {
+                    _state = State.Stopped;
+                    return;
+                }
+                else if (_state == State.Stopped)
+                {
+                    return;
+                }
+            }
+
+            await CloseAcceptAsync();
+
+            TaskCompletionSource<object> tcs = null;
+            bool triggerStateChange = false;
+            lock (_gate)
+            {
+                if (_state == State.Stopped)
+                {
+                    return;
+                }
+                else if (_state == State.Stopping)
+                {
+                    tcs = _stateChangeCompletion;
+                }
+                else if (_state == State.AcceptClosed)
+                {
+                    tcs = _stateChangeCompletion = new TaskCompletionSource<object>();
+                    _state = State.Stopping;
+                    triggerStateChange = true;
+                }
+                else
+                {
+                    // Cannot happen
+                    ThrowInvalidState();
+                }
+            }
+            if (triggerStateChange)
+            {
+                _pipeEnds.WriteEnd.WriteByte(0);
+            }
+            await tcs.Task;
+        }
+
+        private unsafe void PollThread(object obj)
+        {
+            // TODO: add try catch
+            bool notPacked = !EPoll.PackedEvents;
+            var buffer = stackalloc int[EventBufferLength * (notPacked ? 4 : 3)];
+            bool running = true;
+            while (running)
+            {
+                bool doCloseAccept = false;
+                int numEvents = _epoll.Wait(buffer, EventBufferLength, timeout: EPoll.TimeoutInfinite);
+                int* ptr = buffer;
+                for (int i = 0; i < numEvents; i++)
+                {
+                    //   Packed             Non-Packed
+                    //   ------             ------
+                    // 0:Events       ==    Events
+                    // 1:Int1 = Key         [Padding]
+                    // 2:Int2 = Key   ==    Int1 = Key
+                    // 3:~~~~~~~~~~         Int2 = Key
+                    //                      ~~~~~~~~~~
+                    int events = *ptr++; // 0
+                    ptr++;               // 1
+                    int key = *ptr++;    // 2
+                    if (notPacked)
+                        ptr++;           // 3
+                    TSocket tsocket;
+                    if (_sockets.TryGetValue(key, out tsocket))
+                    {
+                        var type = tsocket.Flags & SocketFlags.TypeMask;
+                        if (type == SocketFlags.TypeAccept && !doCloseAccept)
+                        {
+                            HandleAccept(tsocket);
+                        }
+                        else if (type == SocketFlags.TypeClient)
+                        {
+                            HandleClient(tsocket, (EPollEvents)events);
+                        }
+                        else // TypePipe
+                        {
+                            HandleState(ref running, ref doCloseAccept);
+                        }
+                    }
+                }
+                if (doCloseAccept)
+                {
+                    CloseAccept();
+                }
+            }
+            Stop();
+        }
+
+        private void HandleClient(TSocket tsocket, EPollEvents events)
+        {
+            if ((events & EPollEvents.Error) != 0)
+            {
+                events |= EPollEvents.Readable | EPollEvents.Writable;
+            }
+            lock (tsocket)
+            {
+                // Check what events were registered
+                events = events & (EPollEvents)(SocketFlags.EPollEventMask & tsocket.Flags);
+                // Clear those events
+                tsocket.Flags &= ~(SocketFlags)events;
+                // Re-arm
+                EPollEvents remaining = (EPollEvents)(tsocket.Flags & SocketFlags.EPollEventMask);
+                if (remaining != 0)
+                {
+                    _epoll.Control(EPollOperation.Modify, tsocket.Socket, remaining | EPollEvents.OneShot, new EPollData() { Int1 = tsocket.Key, Int2 = tsocket.Key });
+                }
+            }
+            if ((events & EPollEvents.Readable) != 0)
+            {
+                tsocket.CompleteReadable();
+            }
+            if ((events & EPollEvents.Writable) != 0)
+            {
+                tsocket.CompleteWritable();
+            }
+        }
+
+        private void HandleAccept(TSocket tacceptSocket)
+        {
+            // TODO: should we handle more than 1 accept? If we do, we shouldn't be to eager
+            //       as that might give the kernel the impression we have nothing to do
+            //       which could interfere with the SO_REUSEPORT load-balancing.
+            Socket clientSocket;
+            var result = tacceptSocket.Socket.TryAccept(out clientSocket, blocking: false);
+            if (result.IsSuccess)
+            {
+                int key;
+                TSocket tsocket;
+                try
+                {
+                    key = clientSocket.DangerousGetHandle().ToInt32();
+
+                    tsocket = new TSocket()
+                    {
+                        Flags = SocketFlags.TypeClient,
+                        Key = key,
+                        Socket = clientSocket
+                    };
+
+                    clientSocket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, 1);
+                }
+                catch
+                {
+                    clientSocket.Dispose();
+                    return;
+                }
+
+                var connectionContext = _connectionHandler.OnConnection(
+                        connectionInfo: tsocket,
+                        inputOptions: DefaultPipeOptions,
+                        outputOptions: DefaultPipeOptions);
+                tsocket.PipeReader = connectionContext.Output;
+
+                _sockets.TryAdd(key, tsocket);
+
+                ReadFromSocket(tsocket, connectionContext.Input);
+                WriteToSocket(tsocket, connectionContext.Output);
+            }
+        }
+
+        private async void WriteToSocket(TSocket tsocket, IPipeReader reader)
+        {
+            try
+            {
+                while (true)
+                {
+                    var readResult = await reader.ReadAsync();
+                    var buffer = readResult.Buffer;
+                    try
+                    {
+                        // We need to call Advance to end the read
+
+                        if (buffer.IsEmpty && readResult.IsCompleted)
+                        {
+                            // EOF
+                            reader.Advance(buffer.End);
+                            break;
+                        }
+
+                        if (readResult.IsCancelled)
+                        {
+                            // TransportThread is stopping
+                            reader.Advance(buffer.End);
+                            break;
+                        }
+
+                        if (!buffer.IsEmpty)
+                        {
+                            var result = TrySend(tsocket.Socket, ref buffer);
+                            if (result.IsSuccess)
+                            {
+                                if (result.Value == 0)
+                                {
+                                    // There was no data to send
+                                    reader.Advance(buffer.End);
+                                }
+                                else
+                                {
+                                    var end = buffer.Move(buffer.Start, result.Value);
+                                    reader.Advance(end);
+                                }
+                            }
+                            else if (result == PosixResult.EAGAIN || result == PosixResult.EWOULDBLOCK)
+                            {
+                                bool stopping = await Writable(tsocket);
+                                if (stopping)
+                                {
+                                    // TransportThread is stopping
+                                    reader.Advance(buffer.End);
+                                    break;
+                                }
+                                else
+                                {
+                                    reader.Advance(buffer.Start);
+                                }
+                            }
+                            else
+                            {
+                                result.ThrowOnError();
+                            }
+                        }
+                        else
+                        {
+                            reader.Advance(buffer.End);
+                        }
+                    }
+                    catch
+                    {
+                        reader.Advance(buffer.End);
+                        throw;
+                    }
+                }
+                reader.Complete();
+            }
+            catch (Exception ex)
+            {
+                reader.Complete(ex);
+            }
+            finally
+            {
+                CleanupSocket(tsocket, SocketShutdown.Send);
+            }
+        }
+
+        private static unsafe PosixResult TrySend(Socket socket, ref ReadableBuffer buffer)
+        {
+            // 1KB ioVectors, At +-4KB per Memory -> 256KB send
+            const int MaxIOVecLength = 64;
+
+            int ioVecAllocate = 0;
+            foreach (var memory in buffer)
+            {
+                if (memory.Length == 0) // It happens...
+                {
+                    continue;
+                }
+                ioVecAllocate++;
+                if (ioVecAllocate == MaxIOVecLength)
+                {
+                    break;
+                }
+            }
+            if (ioVecAllocate == 0)
+            {
+                return new PosixResult(0);
+            }
+            var ioVectors = stackalloc IOVector[ioVecAllocate];
+            int i = 0;
+            foreach (var memory in buffer)
+            {
+                if (memory.Length == 0)
+                {
+                    continue;
+                }
+                void* pointer;
+                if (memory.TryGetPointer(out pointer))
+                {
+                    ioVectors[i].Base = (byte*)pointer;
+                    ioVectors[i].Count = new UIntPtr((uint)memory.Length);
+                }
+                else
+                {
+                    throw new InvalidOperationException("Memory needs to be pinned");
+                }
+                i++;
+            }
+
+            return socket.TrySend(ioVectors, ioVecAllocate);
+        }
+
+        private WritableAwaitable Writable(TSocket tsocket)
+        {
+            tsocket.ResetWritableAwaitable();
+            RegisterForEvent(tsocket, EPollEvents.Writable);
+            return tsocket.WritableAwaitable;
+        }
+
+        private async void ReadFromSocket(TSocket tsocket, IPipeWriter writer)
+        {
+            try
+            {
+                while (true)
+                {
+                    bool stopping = await Readable(tsocket);
+                    if (stopping)
+                    {
+                        // TransportThread is stopping
+                        break;
+                    }
+
+                    var availableBytes = tsocket.Socket.GetAvailableBytes();
+                    if (availableBytes == 0)
+                    {
+                        // EOF
+                        break;
+                    }
+
+                    // TODO: allocate to receive availableBytes
+                    // WritableBuffer doesn't support non-contiguous writes
+                    // https://github.com/dotnet/corefxlab/issues/1233
+                    var buffer = writer.Alloc(2048);
+                    try
+                    {
+                        // We need to call FlushAsync or Commit to end the write
+
+                        var result = TryReceive(tsocket.Socket, availableBytes, ref buffer);
+                        if (result.IsSuccess)
+                        {
+                            if (result.Value == 0)
+                            {
+                                // EOF
+                                buffer.Commit();
+                                break;
+                            }
+                            else
+                            {
+                                buffer.Advance(result.Value);
+                                bool readerComplete = !await buffer.FlushAsync();
+                                if (readerComplete)
+                                {
+                                    // The reader has stopped
+                                    break;
+                                }
+                            }
+                        }
+                        else if (result == PosixResult.EAGAIN || result == PosixResult.EWOULDBLOCK)
+                        {
+                            buffer.Commit();
+                        }
+                        else
+                        {
+                            result.ThrowOnError();
+                        }
+                    }
+                    catch
+                    {
+                        buffer.Commit();
+                        throw;
+                    }
+                }
+                writer.Complete();
+            }
+            catch (Exception ex)
+            {
+                writer.Complete(ex);
+            }
+            finally
+            {
+                CleanupSocket(tsocket, SocketShutdown.Receive);
+            }
+        }
+
+        private unsafe PosixResult TryReceive(Socket socket, int availableBytes, ref WritableBuffer buffer)
+        {
+            void* pointer;
+            if (!buffer.Memory.TryGetPointer(out pointer))
+            {
+                throw new InvalidOperationException("Pointer must be pinned");
+            }
+            IOVector ioVector = new IOVector { Base = (byte*) pointer, Count = new UIntPtr((uint)buffer.Memory.Length) };
+            return socket.TryReceive(&ioVector, 1);
+        }
+
+        private ReadableAwaitable Readable(TSocket tsocket)
+        {
+            tsocket.ResetReadableAwaitable();
+            RegisterForEvent(tsocket, EPollEvents.Readable);
+            return tsocket.ReadableAwaitable;
+        }
+
+        private void RegisterForEvent(TSocket tsocket, EPollEvents ev)
+        {
+            lock (tsocket)
+            {
+                if (_state == State.Stopping)
+                {
+                    ThrowInvalidState();
+                }
+                SocketFlags oldFlags = tsocket.Flags;
+                try
+                {
+                    EPollOperation operation = (oldFlags & SocketFlags.EPollRegistered) == 0 ? EPollOperation.Add : EPollOperation.Modify;
+                    tsocket.Flags |= SocketFlags.EPollRegistered | (SocketFlags)ev;
+                    EPollEvents events = (EPollEvents)(tsocket.Flags & SocketFlags.EPollEventMask);
+                    _epoll.Control(operation, tsocket.Socket, events | EPollEvents.OneShot, new EPollData() { Int1 = tsocket.Key, Int2 = tsocket.Key });
+                }
+                catch
+                {
+                    tsocket.Flags = oldFlags;
+                    throw;
+                }
+            }
+        }
+
+        private void CleanupSocket(TSocket tsocket, SocketShutdown shutdown)
+        {
+            lock (tsocket)
+            {
+                bool close = false;
+                if (shutdown == SocketShutdown.Send)
+                {
+                    tsocket.Flags |= SocketFlags.ShutdownSend;
+                    close = (tsocket.Flags & SocketFlags.ShutdownReceive) != 0;
+                }
+                else
+                {
+                    tsocket.Flags |= SocketFlags.ShutdownReceive;
+                    close = (tsocket.Flags & SocketFlags.ShutdownSend) != 0;
+                }
+
+                if (close)
+                {
+                    TSocket removedSocket;
+                    _sockets.TryRemove(tsocket.Key, out removedSocket);
+                    tsocket.Socket.Dispose();
+                }
+                else
+                {
+                    tsocket.Socket.TryShutdown(shutdown);
+                }
+            }
+        }
+
+        private void Stop()
+        {
+            _epoll.BlockingDispose();
+
+            var pipeReadKey = _pipeEnds.ReadEnd.DangerousGetHandle().ToInt32();
+            TSocket pipeReadSocket;
+            _sockets.TryRemove(pipeReadKey, out pipeReadSocket);
+            _pipeEnds.Dispose();
+
+            foreach (var kv in _sockets)
+            {
+                var tsocket = kv.Value;
+                tsocket.PipeReader.CancelPendingRead();
+                EPollEvents pending = EPollEvents.None;
+                lock (tsocket)
+                {
+                    pending = (EPollEvents)(tsocket.Flags & SocketFlags.EPollEventMask);
+                    tsocket.Flags &= ~(SocketFlags)pending;
+                }
+                if ((pending & EPollEvents.Readable) != 0)
+                {
+                    tsocket.CompleteReadable(stopping: true);
+                }
+                if ((pending & EPollEvents.Writable) != 0)
+                {
+                    tsocket.CompleteWritable(stopping: true);
+                }
+            }
+
+            TaskCompletionSource<object> tcs;
+            lock (_gate)
+            {
+                tcs = _stateChangeCompletion;
+                _stateChangeCompletion = null;
+                _state = State.Stopped;
+            }
+            tcs.SetResult(null);
+        }
+
+        private void CloseAccept()
+        {
+            foreach (var acceptSocket in _acceptSockets)
+            {
+                TSocket removedSocket;
+                _sockets.TryRemove(acceptSocket.Key, out removedSocket);
+                _epoll.Control(EPollOperation.Delete, removedSocket.Socket, EPollEvents.None, new EPollData());
+                acceptSocket.Socket.Dispose();
+            }
+            _acceptSockets.Clear();
+            TaskCompletionSource<object> tcs;
+            lock (_gate)
+            {
+                tcs = _stateChangeCompletion;
+                _stateChangeCompletion = null;
+                _state = State.AcceptClosed;
+            }
+            tcs.SetResult(null);
+        }
+
+        private unsafe void HandleState(ref bool running, ref bool doCloseAccept)
+        {
+            _pipeEnds.ReadEnd.TryReadByte();
+            lock (_gate)
+            {
+                if (_state == State.ClosingAccept)
+                {
+                    doCloseAccept = true;
+                }
+                else if (_state == State.Stopping)
+                {
+                    running = false;
+                }
+            }
+        }
+
+        private void ThrowInvalidState()
+        {
+            throw new InvalidOperationException($"nameof(TransportThread) is {_state}");
+        }
+    }
+}

--- a/src/Tmds.Kestrel.Linux/TransportThread.cs
+++ b/src/Tmds.Kestrel.Linux/TransportThread.cs
@@ -328,7 +328,9 @@ namespace Tmds.Kestrel.Linux
                     {
                         Flags = SocketFlags.TypeClient,
                         Key = key,
-                        Socket = clientSocket
+                        Socket = clientSocket,
+                        PeerAddress = clientSocket.GetPeerIPAddress(),
+                        LocalAddress = clientSocket.GetLocalIPAddress()
                     };
 
                     clientSocket.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, 1);

--- a/src/Tmds.Kestrel.Linux/TransportThread.cs
+++ b/src/Tmds.Kestrel.Linux/TransportThread.cs
@@ -626,7 +626,8 @@ namespace Tmds.Kestrel.Linux
                 {
                     TSocket removedSocket;
                     _sockets.TryRemove(tsocket.Key, out removedSocket);
-                    tsocket.Socket.Dispose();
+                    // close causes remove from epoll (CLOEXEC)
+                    tsocket.Socket.Dispose(); // will close (no concurrent users)
                 }
                 else
                 {
@@ -680,8 +681,8 @@ namespace Tmds.Kestrel.Linux
             {
                 TSocket removedSocket;
                 _sockets.TryRemove(acceptSocket.Key, out removedSocket);
-                _epoll.Control(EPollOperation.Delete, removedSocket.Socket, EPollEvents.None, new EPollData());
-                acceptSocket.Socket.Dispose();
+                // close causes remove from epoll (CLOEXEC)
+                acceptSocket.Socket.Dispose(); // will close (no concurrent users)
             }
             _acceptSockets.Clear();
             TaskCompletionSource<object> tcs;

--- a/src/Tmds.Kestrel.Linux/project.json
+++ b/src/Tmds.Kestrel.Linux/project.json
@@ -16,7 +16,9 @@
     "netcoreapp1.0": {
       "dependencies": {
         "NETStandard.Library": "1.6.1",
-        "Tmds.Posix": "0.1.0-master-linux-*"
+        "Tmds.Posix": "0.1.0-master-linux-*",
+        "System.Threading.Thread": "4.3.0",
+        "System.IO.Pipelines": "0.1.0-*"
       }
     }
   },

--- a/test/Tmds.Kestrel.Linux.Test/TransportTests.TestServer.cs
+++ b/test/Tmds.Kestrel.Linux.Test/TransportTests.TestServer.cs
@@ -1,0 +1,104 @@
+using System;
+using System.IO.Pipelines;
+using System.Net;
+using System.Threading.Tasks;
+using Kestrel;
+using Tmds.Kestrel.Linux;
+
+namespace Tests
+{
+    class TestServer : IConnectionHandler, IDisposable
+    {
+        public delegate void ConnectionHandler(IPipeReader input, IPipeWriter output);
+
+        class ConnectionContext : IConnectionContext
+        {
+            public ConnectionContext(string connectionId, IPipeWriter input, IPipeReader output)
+            {
+                ConnectionId = connectionId;
+                Input = input;
+                Output = output;
+            }
+            public string ConnectionId { get; }
+            public IPipeWriter Input { get; }
+            public IPipeReader Output { get; }
+        }
+
+        private PipeFactory _pipeFactory;
+        private Transport _transport;
+        private IPEndPoint _serverAddress;
+        private ConnectionHandler _connectionHandler;
+
+        public TestServer(ConnectionHandler connectionHandler, int threadCount = 1)
+        {
+            _connectionHandler = connectionHandler;
+            _pipeFactory = new PipeFactory();
+            _serverAddress = new IPEndPoint(IPAddress.Loopback, 0);
+            var transportOptions = new TransportOptions()
+            {
+                ThreadCount = threadCount
+            };
+            _transport = new Transport(new IPEndPoint[] { _serverAddress }, this, transportOptions);
+            _connectionHandler = connectionHandler;
+        }
+
+        public Task BindAsync()
+        {
+            return _transport.BindAsync();
+        }
+
+        public Task UnbindAsync()
+        {
+            return _transport.UnbindAsync();
+        }
+
+        public Task StopAsync()
+        {
+            return _transport.StopAsync();
+        }
+
+        public IConnectionContext OnConnection(IConnectionInformation connectionInfo, PipeOptions inputOptions, PipeOptions outputOptions)
+        {
+            var input = _pipeFactory.Create(inputOptions);
+            var output = _pipeFactory.Create(outputOptions);
+
+            _connectionHandler(input.Reader, output.Writer);
+
+            return new ConnectionContext(string.Empty, input.Writer, output.Reader);
+        }
+
+        public void Dispose()
+        {
+            _transport.Dispose(); 
+        }
+
+        public static async void Echo(IPipeReader input, IPipeWriter output)
+        {
+            while (true)
+            {
+                var result = await input.ReadAsync();
+                var request = result.Buffer;
+
+                if (request.IsEmpty && result.IsCompleted)
+                {
+                    input.Advance(request.End);
+                    break;
+                }
+
+                int len = request.Length;
+                var response = output.Alloc();
+                response.Append(request);
+                await response.FlushAsync();
+                input.Advance(request.End);
+            }
+        }
+
+        public Socket ConnectTo()
+        {
+            var client = Socket.Create(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp, blocking: true);
+            client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.NoDelay, 1);
+            client.Connect(_serverAddress);
+            return client;
+        }
+    }
+}

--- a/test/Tmds.Kestrel.Linux.Test/TransportTests.cs
+++ b/test/Tmds.Kestrel.Linux.Test/TransportTests.cs
@@ -68,7 +68,7 @@ namespace Tests
 
                     // receive returns EOF                
                     byte[] receiveBuffer = new byte[10];
-                var received = client.Receive(new ArraySegment<byte>(receiveBuffer));
+                    var received = client.Receive(new ArraySegment<byte>(receiveBuffer));
                     Assert.Equal(0, received);
 
                     // send returns EPIPE

--- a/test/Tmds.Kestrel.Linux.Test/TransportTests.cs
+++ b/test/Tmds.Kestrel.Linux.Test/TransportTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO.Pipelines;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Tmds.Kestrel.Linux;
+using Tmds.Posix;
+using Xunit;
+
+namespace Tests
+{
+    public class TransportTests
+    {
+        [Fact]
+        public async Task Echo()
+        {
+            using (var testServer = new TestServer(TestServer.Echo))
+            {
+                await testServer.BindAsync();
+                using (var client = testServer.ConnectTo())
+                {
+                    // Send some bytes
+                    byte[] sendBuffer = new byte[] { 1, 2, 3 };
+                    client.Send(new ArraySegment<byte>(sendBuffer));
+
+                    // Read the echo
+                    byte[] receiveBuffer = new byte[10];
+                    var received = client.Receive(new ArraySegment<byte>(receiveBuffer));
+                    Assert.Equal(sendBuffer.Length, received);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task MultiThread()
+        {
+            using (var testServer = new TestServer(connectionHandler: null, threadCount: 2))
+            {
+                await testServer.BindAsync();
+                await testServer.UnbindAsync();
+                await testServer.StopAsync();
+            }
+        }
+
+        [Fact]
+        public async Task Unbind()
+        {
+            using (var testServer = new TestServer(TestServer.Echo))
+            {
+                await testServer.BindAsync();
+                await testServer.UnbindAsync();
+                var exception = Assert.Throws<PosixException>(() => testServer.ConnectTo());
+                Assert.Equal(PosixResult.ECONNREFUSED, exception.Error);
+            }
+        }
+
+        [Fact]
+        public async Task StopDisconnectsClient()
+        {
+            using (var testServer = new TestServer(TestServer.Echo))
+            {
+                await testServer.BindAsync();
+
+                using (var client = testServer.ConnectTo())
+                {
+                    await testServer.UnbindAsync();
+                    await testServer.StopAsync();
+
+                    // receive returns EOF                
+                    byte[] receiveBuffer = new byte[10];
+                var received = client.Receive(new ArraySegment<byte>(receiveBuffer));
+                    Assert.Equal(0, received);
+
+                    // send returns EPIPE
+                    var exception = Assert.Throws<PosixException>(() =>
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            byte[] sendBuffer = new byte[] { 1, 2, 3 };
+                            client.Send(new ArraySegment<byte>(sendBuffer));
+                        }                    
+                    });
+                    Assert.Equal(PosixResult.EPIPE, exception.Error);
+                }
+            }
+        }
+    }
+}

--- a/test/Tmds.Kestrel.Linux.Test/project.json
+++ b/test/Tmds.Kestrel.Linux.Test/project.json
@@ -22,7 +22,8 @@
         "Microsoft.NETCore.App": {
           "type": "platform",
           "version": "1.0.1"
-        }
+        },
+        "System.IO.Pipelines": "0.1.0-*"
       }
     }
   },


### PR DESCRIPTION
This implements a Linux Transport for Kestrel based on the available information the Kestrel repo and the corefxlab pipeline implementation.

@davidfowl @halter73 could you do a review? The TransferThread.ReadFromSocket and TransferThread.WriteToSocket is where the socket and the pipelines meet. I know you are quite busy, so if I can get your input on the pipeline (ab)usage that would be great. If you can spare some more time, feel free to comment on the entire PR.