### PR TITLE
Socket.TryReceive: bugfix, use Offset

### DIFF
--- a/test/Tmds.Kestrel.Linux.Test/TransportTests.cs
+++ b/test/Tmds.Kestrel.Linux.Test/TransportTests.cs
@@ -262,10 +262,6 @@ namespace Tests
             Assert.True(segment.Count % 4 == 0);
             fixed (byte* bytePtr = segment.Array)
             {
-                if (s_travis)
-                {
-                    System.Console.WriteLine($"AssertCounter {new IntPtr(bytePtr)}, {segment.Count} bytes, starting at {value}");
-                }
                 int* intPtr = (int*)(bytePtr + segment.Offset);
                 for (int i = 0; i < segment.Count / 4; i++)
                 {
@@ -326,7 +322,5 @@ namespace Tests
             }
             remainderRef = remainder;
         }
-
-        private static bool s_travis = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TRAVIS"));
     }
 }


### PR DESCRIPTION
TransportTests.Send occasionally failed because TryReceive did not take Offset into account