### PR TITLE
Alternative read strategy which does fixed sized reads

### DIFF
--- a/src/Tmds.Kestrel.Linux/Transport.cs
+++ b/src/Tmds.Kestrel.Linux/Transport.cs
@@ -58,10 +58,16 @@ namespace Tmds.Kestrel.Linux
             var original = Interlocked.CompareExchange(ref _threads, threads, null);
             ThrowIfInvalidState(state: original, starting: true);
 
+            IPEndPoint[] endPoints = Interlocked.Exchange(ref _listenEndPoints, null);
+            if (endPoints == null)
+            {
+                throw new InvalidOperationException("Already bound");
+            }
+
             for (int i = 0; i < threads.Length; i++)
             {
                 threads[i].Start();
-                foreach (var listenEndPoint in _listenEndPoints)
+                foreach (var listenEndPoint in endPoints)
                 {
                     threads[i].AcceptOn(listenEndPoint);
                 }

--- a/src/Tmds.Kestrel.Linux/TransportOptions.cs
+++ b/src/Tmds.Kestrel.Linux/TransportOptions.cs
@@ -2,11 +2,23 @@ using System;
 
 namespace Tmds.Kestrel.Linux
 {
+    public enum ReadStrategy
+    {
+        // Attempt to read a fixed amount of data
+        // This may leave data pending
+        Fixed,
+        // Read data based on how much is available
+        // Requires querying amount of available data
+        Available
+    }
+
     public class TransportOptions
     {
         public int ThreadCount { get; set; } = ProcessorThreadCount;
 
         public bool DeferAccept { get; set; } = true;
+
+        public ReadStrategy ReadStrategy { get; set; } = ReadStrategy.Available;
 
         private static int ProcessorThreadCount
         {


### PR DESCRIPTION
The current implementation attempts to receive the available bytes on the socket. So we need to query the available bytes first before reading. This strategy just performs a single buffer read independent of the number of available bytes. This may leave many bytes available in the kernel.